### PR TITLE
Fix memory handling issues

### DIFF
--- a/python_mdtr/mdrender.c
+++ b/python_mdtr/mdrender.c
@@ -1,6 +1,8 @@
 #include "../include/string_buffer.h"
 #include "../include/styles.h"
 #include "../include/stylestack.h"
+#include <stdlib.h>
+#include <string.h>
 
 void __sv_char(StringBuffer *sb, const char *string, int64_t *i, int64_t len, StyleStack *stack, int is_newline, int *in_code_block) {
     while (*i < len) {
@@ -159,6 +161,11 @@ __attribute__((visibility("default"))) const char *get_terminal_markdown_string(
     }
 
     char *result = string_buffer_to_string(sb);
+    string_buffer_free(sb);
 
     return result;
+}
+
+__attribute__((visibility("default"))) void free_rendered_string(const char *str) {
+    free((void *)str);
 }

--- a/python_mdtr/mdrender.h
+++ b/python_mdtr/mdrender.h
@@ -3,5 +3,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 extern const char *get_terminal_markdown_string(const char *string);
+extern void free_rendered_string(const char *string);
 
 #endif // MDRENDER_H

--- a/python_mdtr/mdtr.py
+++ b/python_mdtr/mdtr.py
@@ -1,7 +1,13 @@
 import ctypes
+
 mdrender = ctypes.CDLL("./libmdrender.so")
-mdrender.get_terminal_markdown_string.restype = ctypes.c_char_p
+mdrender.get_terminal_markdown_string.restype = ctypes.c_void_p
+mdrender.free_rendered_string.argtypes = [ctypes.c_void_p]
+mdrender.free_rendered_string.restype = None
+
 
 def get_terminal_markdown_string(string: str) -> str:
-    result = mdrender.get_terminal_markdown_string(string.encode("utf-8"))
-    return result.decode("utf-8")
+    ptr = mdrender.get_terminal_markdown_string(string.encode("utf-8"))
+    text = ctypes.string_at(ptr).decode("utf-8")
+    mdrender.free_rendered_string(ptr)
+    return text

--- a/src/string_buffer.c
+++ b/src/string_buffer.c
@@ -3,17 +3,24 @@
 #include <string.h>
 
 StringBuffer *string_buffer_create(size_t initial_capacity) {
+    size_t capacity = initial_capacity + 1; // space for null-terminator
+    if (capacity == 0) {
+        capacity = 1;
+    }
     StringBuffer *sb = malloc(sizeof(StringBuffer));
-    sb->data = malloc(initial_capacity);
+    sb->data = malloc(capacity);
     sb->data[0] = '\0';
     sb->size = 0;
-    sb->capacity = initial_capacity;
+    sb->capacity = capacity;
     return sb;
 }
 
 static void string_buffer_grow(StringBuffer *sb, size_t min_capacity) {
+    if (sb->capacity == 0) {
+        sb->capacity = 1;
+    }
     while (sb->capacity < min_capacity) {
-        sb->capacity = (size_t)(sb->capacity * 1.5);
+        sb->capacity = (size_t)(sb->capacity * 2);
     }
     sb->data = realloc(sb->data, sb->capacity);
 }


### PR DESCRIPTION
## Summary
- allocate space for null terminators when creating string buffers
- guard against zero capacity when growing buffers
- free temporary buffer in Python wrapper's C code
- expose a helper to free rendered strings and use it in Python API

## Testing
- `gcc -shared -fPIC -Iinclude python_mdtr/mdrender.c src/string_buffer.c src/styles.c src/stylestack.c -o libmdrender.so`
- `python3 python_mdtr/main.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687127ab3074832e954e3458d23bd027